### PR TITLE
Hiding Google Ad Slots divs Only if no add is available

### DIFF
--- a/lib/dfp_helper.rb
+++ b/lib/dfp_helper.rb
@@ -39,13 +39,13 @@ var #{options[:slot_name]};
 </script>
       END
     end
-    
+
     def dfp_helper_head(options={single_request:true})
       return unless dfp_helper_slots.size > 0
       o = dfp_helper_slots.collect{|i|
         _targeting = (i[:targeting]||[]).collect{|k,v| ".setTargeting(#{k.to_json}, #{v.to_json})"}.join
         _slot_name = (i[:slot_name].blank?)?"":"#{i[:slot_name]} = "
-        "#{_slot_name}googletag.defineSlot('#{i[:id]}', [#{i[:size].map(&:to_s).join(', ')}], '#{i[:div_id]}').addService(googletag.pubads())#{_targeting};"
+        "#{_slot_name}googletag.defineSlot('#{i[:id]}', [#{i[:size].map(&:to_s).join(', ')}], '#{i[:div_id]}').setCollapseEmptyDiv(true).addService(googletag.pubads())#{_targeting};"
       }.join("\n")
       sra = "googletag.pubads().enableSingleRequest();" if options[:single_request]
       raw <<-END.strip

--- a/lib/dfp_helper.rb
+++ b/lib/dfp_helper.rb
@@ -23,7 +23,7 @@ module DfpHelper
 <script type='text/javascript'>
 googletag.cmd.push(function() {
   if(#{options[:hide_empty]}) {
-      window.ww_ad_slots['#{_i}'].setCollapseEmptyDiv(true);
+      window.gtag_ad_slots['#{_i}'].setCollapseEmptyDiv(true);
   }
   googletag.display('#{_id}');
 });
@@ -51,13 +51,13 @@ var #{options[:slot_name]};
       o = dfp_helper_slots.collect{|i|
         _targeting = (i[:targeting]||[]).collect{|k,v| ".setTargeting(#{k.to_json}, #{v.to_json})"}.join
         _slot_name = (i[:slot_name].blank?)?"":"#{i[:slot_name]} = "
-        "window.ww_ad_slots['#{i[:id]}'] = #{_slot_name}googletag.defineSlot('#{i[:id]}', [#{i[:size].map(&:to_s).join(', ')}], '#{i[:div_id]}').addService(googletag.pubads())#{_targeting};"
+        "window.gtag_ad_slots['#{i[:id]}'] = #{_slot_name}googletag.defineSlot('#{i[:id]}', [#{i[:size].map(&:to_s).join(', ')}], '#{i[:div_id]}').addService(googletag.pubads())#{_targeting};"
       }.join("\n")
       sra = "googletag.pubads().enableSingleRequest();" if options[:single_request]
       raw <<-END.strip
 <script type='text/javascript'>
 var googletag = googletag || {};
-var ww_ad_slots = ww_ad_slots || {};
+var gtag_ad_slots = gtag_ad_slots || {};
 googletag.cmd = googletag.cmd || [];
 (function() {
 var gads = document.createElement('script');


### PR DESCRIPTION
This PR adds: `setCollapseEmptyDiv(true)` to have the ad slots divs collapsed ONLY after no ads are available. 

I believe none of our current WW ads should be drastically affected since this method only collapses the divs when there are no ads. (similar to #4 but using not a global method call)

_P.S. Maybe I better way of doing this would be to somehow add this call as an option in the method `dfp_helper_slot` in dfp_helper.rb, however I couldn't figure out if there is a way clean of doing this._

Reference: https://developers.google.com/doubleclick-gpt/reference?hl=en#googletag.Slot_setCollapseEmptyDiv

@chancedowns What are your thoughts?